### PR TITLE
fty_common_mlm_subprocess.cc : improve test success chances…

### DIFF
--- a/src/fty_common_mlm_subprocess.cc
+++ b/src/fty_common_mlm_subprocess.cc
@@ -813,7 +813,7 @@ fty_common_mlm_subprocess_test (bool verbose)
     MlmSubprocess::SubProcess proc(argv);
     bret = proc.run();
     assert(bret);
-    usleep(50);
+    usleep(50000);
 
     ret = proc.kill();
     assert(ret == 0);
@@ -843,7 +843,7 @@ fty_common_mlm_subprocess_test (bool verbose)
     MlmSubprocess::SubProcess proc(argv);
     bret = proc.run();
     assert(bret);
-    usleep(50);
+    usleep(50000);
 
     ret = proc.terminate();
     assert(ret == 0);


### PR DESCRIPTION
…wait longer for `sleep&` startup before killing it