### PR TITLE
Problem: subprocess termination is too ungraceful (and mis-named)

### DIFF
--- a/include/fty_common_mlm_subprocess.h
+++ b/include/fty_common_mlm_subprocess.h
@@ -73,8 +73,8 @@ class SubProcess {
         //! \brief get the pipe ends connected to stdin of started program, or -1 if not started
         int getStdin() const { return _inpair[1]; }
 
-	//! \brief close the stdin pipe end
-	int closeStdin();
+        //! \brief close the stdin pipe end
+        int closeStdin();
 
         //! \brief get the pipe ends connected to stdout of started program, or -1 if not started
         int getStdout() const { return _outpair[0]; }
@@ -116,7 +116,7 @@ class SubProcess {
 
         //! \brief kill the subprocess with defined signal, default SIGTERM/15
         //
-        //  @param signal - signal, defaul is SIGTERM
+        //  @param signal - signal, default is SIGTERM
         //
         //  @return see kill(2)
         int kill(int signal=SIGTERM);

--- a/include/fty_common_mlm_subprocess.h
+++ b/include/fty_common_mlm_subprocess.h
@@ -126,6 +126,12 @@ class SubProcess {
         //  This calls wait() to ensure we are not creating zombies
         //
         //  @return \see kill
+        int hardkill();
+
+        //! \brief gracefully terminate the subprocess with SIGTERM/15,
+        //   check if died quickly, hardkill() otherwise
+        //
+        //  @return \see kill
         int terminate();
 
         const char* state() const;


### PR DESCRIPTION
Solution: have hardkill() for original terminate() job, and terminate() children gracefully thus fixing naming of routines vs. common OS terminology
* This commit transplants the lost bits of code from https://github.com/42ity/fty-rest/pull/482 and updates self-tests for it
* A bit of other cleanup
