### PR TITLE
Problem : we need a c++ wrapper memory clean of zmsg_popstr

### DIFF
--- a/include/fty_common_mlm_guards.h
+++ b/include/fty_common_mlm_guards.h
@@ -63,5 +63,6 @@ typedef MlmObjGuard<zpoller_t, zpoller_destroy> ZpollerGuard;
 typedef MlmObjGuard<zmsg_t, zmsg_destroy> ZmsgGuard;
 typedef MlmObjGuard<zuuid_t, zuuid_destroy> ZuuidGuard;
 typedef MlmObjGuard<char, zstr_free> ZstrGuard;
+typedef MlmObjGuard<zconfig_t, zconfig_destroy> ZconfigGuard;
 
 #endif

--- a/include/fty_common_mlm_utils.h
+++ b/include/fty_common_mlm_utils.h
@@ -39,12 +39,12 @@ namespace MlmUtils {
     zhash_t *
     map_to_zhash (std::map<std::string, std::string> map_to_convert);
 
-} //namespace
+    /** \brief do a memory clean zmsg_popstr call
+     *   \return a std::string object
+     */
+    std::string zmsg_popstring(zmsg_t *resp);
 
-/** \brief do a memory clean zmsg_popstr call
- *   \return a std::string object
- */
-std::string zmsg_popstring(zmsg_t *resp);
+} //namespace
 
 void
 fty_common_mlm_utils_test (bool verbose);

--- a/include/fty_common_mlm_utils.h
+++ b/include/fty_common_mlm_utils.h
@@ -41,6 +41,11 @@ namespace MlmUtils {
 
 } //namespace
 
+/** \brief do a memory clean zmsg_popstr call
+ *   \return a std::string object
+ */
+std::string zmsg_popstring(zmsg_t *resp);
+
 void
 fty_common_mlm_utils_test (bool verbose);
 

--- a/src/fty_common_mlm_utils.cc
+++ b/src/fty_common_mlm_utils.cc
@@ -208,3 +208,4 @@ std::string zmsg_popstring(zmsg_t *resp){
     zstr_free (&popstr);
     return string_rv;
 }
+

--- a/src/fty_common_mlm_utils.cc
+++ b/src/fty_common_mlm_utils.cc
@@ -1,7 +1,7 @@
 /*  =========================================================================
-    fty_common_mlm_utils - class description
+    fty_common_mlm_utils - common malamute utils 
 
-    Copyright (C) 2014 - 2018 Eaton
+    Copyright (C) 2014 - 2019 Eaton
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -199,4 +199,12 @@ fty_common_mlm_utils_test (bool verbose)
     }
 
     printf ("fty-common-mlm-utils OK\n");
+}
+
+std::string zmsg_popstring(zmsg_t *resp){
+    char *popstr = zmsg_popstr (resp);
+    //copies the null-terminated character sequence (C-string) pointed by popstr
+    std::string string_rv = popstr;
+    zstr_free (&popstr);
+    return string_rv;
 }


### PR DESCRIPTION
Solution : implement a std::string zmsg_popstring(zmsg_t *resp) wrapper function
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>